### PR TITLE
Add instruction about port mapping

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,16 @@ Log onto your Dokku Host to create the minio app
 dokku apps:create minio
 ```
 
+### Configure vhost port mapping
+
+By default, [dokku will bind to dokku host's `9000` port](http://dokku.viewdocs.io/dokku/advanced-usage/proxy-management/#proxy-port-mapping). If you want to avoid it and use specific port to bind, run `dokku proxy:ports-add` command **before** you do first `git push`.
+
+For example, following command will map to `80` port and will avoid creating `http:9000:9000` port mapping.
+
+```bash
+dokku proxy:ports-add minio http:80:9000
+```
+
 ### Set Environment Variables
 minio uses an **access key** and **secret key** for login, and object management. You can set custom keys with /[Environment Variables](http://dokku.viewdocs.io/dokku/configuration/environment-variables/)/. if keys aren't set, minio server will generate them.
 ```


### PR DESCRIPTION
## Situation

I think we (dokku users) expects applications which is deployed to dokku will be exposed `80` port of each application's virtual hostname. For example, an app which named `app-foo` is expected to be exposed as `app-foo.example.com:80`.

Because minio-dokku's Dockerfile extends the minio's official Dockerfile. It contins `EXPOSE 9000` so dokku will create port mapping configuration to host minio on `9000` port on host.

Detailed rule of port mapping auto generation:
http://dokku.viewdocs.io/dokku/advanced-usage/proxy-management/#proxy-port-mapping

>By default, buildpack apps and dockerfile apps without explicitly exposed ports (i.e. using the EXPOSE directive) will be configured with a listener on port 80 (and additionally a listener on 443 if ssl is enabled) that will proxy to the application container on port 5000. Dockerfile apps with explicitly exposed ports will be configured with a listener on each exposed port and will proxy to that same port of the deployed application container.

The best way is start mino server with `--address ":5000"` option and not use `EXPOSE` command in Dockerfile, but we can't remove parent Dockerfile's `EXPOSE` command [for now](https://github.com/moby/moby/issues/3465), so we can't change default port-mapping by Dockerfile while it extends minio's official Dockerfile.

## Solution

I added to instruction to avoid `http:9000:9000` port mapping and create `http:80:5000` one.