### PR TITLE
Fix nginx HTTP 413 error (request entity too large)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,9 @@ USER dokku
 # Create data directory for the user, where we will keep the data
 RUN mkdir -p /home/dokku/data
 
+# Add custom nginx.conf template for Dokku to use
+WORKDIR /app
+ADD nginx.conf.sigil .
+
 # Run the server and point to the created directory
 CMD ["server", "/home/dokku/data"]

--- a/README.md
+++ b/README.md
@@ -54,13 +54,16 @@ in on your host running dokku via `dokku config minio`.
 > startup and output them to the log (check if via `dokku logs minio`). You
 > will still need to set them manually.
 
-You'll also need to set `NGINX_MAX_REQUEST_BODY` - this variable is used in the
-custom `nginx.conf` for this Dokku app to allow uploads up to 15MB to the HTTP
-server (if the file size is greater than 15MB, `s3cmd` will split in 15MB
-parts). To set the variable, execute the following command:
+You'll also need to set other two environment variables:
+
+- `NGINX_MAX_REQUEST_BODY`: used in the custom `nginx.conf` for this Dokku app
+  to allow uploads up to 15MB to the HTTP server (if the file size is greater
+  than 15MB, `s3cmd` will split in 15MB parts).
+- `MINIO_DOMAIN`: used to tell minio the domain name being used by the server.
 
 ```bash
 dokku config:set --no-restart minio NGINX_MAX_REQUEST_BODY=15M
+dokku config:set --no-restart minio MINIO_DOMAIN=minio.example.com
 ```
 
 > **Note**: if you're using [s4cmd](https://github.com/bloomreach/s4cmd/)
@@ -137,7 +140,8 @@ git remote add dokku dokku@example.com:minio
 
 ### Push Minio
 
-Now we can push Minio to Dokku (_before_ moving on to the [next part](#domain-and-ssl-certificate)).
+Now we can push Minio to Dokku (_before_ moving on to the [next
+part](#domain-and-ssl-certificate)).
 
 ```bash
 git push dokku master
@@ -151,8 +155,13 @@ Encrypt](https://letsencrypt.org/).
 ```bash
 dokku config:set --no-restart minio DOKKU_LETSENCRYPT_EMAIL=you@example.com
 dokku letsencrypt minio
+dokku proxy:ports-set minio https:443:9000
 ```
+
+> **Note**: you must execute these steps *after* pushing the app to Dokku
+> host.
 
 ## Wrapping up
 
-Your Minio instance should now be available on [`https://minio.example.com`](https://minio.example.com).
+Your Minio instance should now be available on
+[minio.example.com](https://minio.example.com).

--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ storage service. Read more at the [minio.io](https://www.minio.io/) website.
 you've ever seen - _Docker powered mini-Heroku_.
 
 ### Requirements
+
 * A working [Dokku host](http://dokku.viewdocs.io/dokku/getting-started/installation/)
 
 # Setup
 
-**Note:** We are going to use the domain `minio.example.com` for demonstration
-purposes. Make sure to replace it to your domain name.
+We are going to use the domain `minio.example.com` and dokku app `minio` for
+demonstration purposes. Make sure to replace it.
 
 ## Create the app
+
 Log onto your Dokku Host to create the Minio app:
 
 ```bash
@@ -33,24 +35,37 @@ dokku apps:create minio
 
 ## Configuration
 
-### Setting access keys
+### Setting environment variables
 
 Minio uses two access keys (`ACCESS_KEY` and `SECRET_KEY`) for authentication
 and object management. The following commands sets a random strings for each
 access key.
 
 ```bash
-dokku config:set minio MINIO_ACCESS_KEY=$(echo `openssl rand -base64 45` | tr -d \=+ | cut -c 1-20)
-dokku config:set minio MINIO_SECRET_KEY=$(echo `openssl rand -base64 45` | tr -d \=+ | cut -c 1-32)
+dokku config:set --no-restart minio MINIO_ACCESS_KEY=$(echo `openssl rand -base64 45` | tr -d \=+ | cut -c 1-20)
+dokku config:set --no-restart minio MINIO_SECRET_KEY=$(echo `openssl rand -base64 45` | tr -d \=+ | cut -c 1-32)
 ```
 
 To login in the browser or via API, you will need to supply both the
 `ACCESS_KEY` and `SECRET_KEY`. You can retrieve these at any time while logged
 in on your host running dokku via `dokku config minio`.
 
-**Note:** If you do not set these keys, Minio will generate them during startup
-and output them to the log (check if via `dokku logs minio`). You will still
-need to set them manually.
+> **Note:** if you do not set these keys, Minio will generate them during
+> startup and output them to the log (check if via `dokku logs minio`). You
+> will still need to set them manually.
+
+You'll also need to set `NGINX_MAX_REQUEST_BODY` - this variable is used in the
+custom `nginx.conf` for this Dokku app to allow uploads up to 15MB to the HTTP
+server (if the file size is greater than 15MB, `s3cmd` will split in 15MB
+parts). To set the variable, execute the following command:
+
+```bash
+dokku config:set --no-restart minio NGINX_MAX_REQUEST_BODY=15M
+```
+
+> **Note**: if you're using [s4cmd](https://github.com/bloomreach/s4cmd/)
+> instead, be sure to pass the following parameters:
+> `--multipart-split-size=15728640 --max-singlepart-upload-size=15728640`.
 
 
 ## Persistent storage

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ you've ever seen - _Docker powered mini-Heroku_.
 
 # Setup
 
-We are going to use the domain `minio.example.com` and dokku app `minio` for
+We are going to use the domain `minio.example.com` and Dokku app `minio` for
 demonstration purposes. Make sure to replace it.
 
 ## Create the app
@@ -59,7 +59,7 @@ You'll also need to set other two environment variables:
 - `NGINX_MAX_REQUEST_BODY`: used in the custom `nginx.conf` for this Dokku app
   to allow uploads up to 15MB to the HTTP server (if the file size is greater
   than 15MB, `s3cmd` will split in 15MB parts).
-- `MINIO_DOMAIN`: used to tell minio the domain name being used by the server.
+- `MINIO_DOMAIN`: used to tell Minio the domain name being used by the server.
 
 ```bash
 dokku config:set --no-restart minio NGINX_MAX_REQUEST_BODY=15M

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -1,0 +1,169 @@
+{{ range $port_map := .PROXY_PORT_MAP | split " " }}
+{{ $port_map_list := $port_map | split ":" }}
+{{ $scheme := index $port_map_list 0 }}
+{{ $listen_port := index $port_map_list 1 }}
+{{ $upstream_port := index $port_map_list 2 }}
+
+{{ if eq $scheme "http" }}
+server {
+  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }};
+  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }};
+  {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
+  access_log  {{ $.NGINX_ACCESS_LOG_PATH }};
+  error_log   {{ $.NGINX_ERROR_LOG_PATH }};
+  client_max_body_size {{ var "NGINX_MAX_REQUEST_BODY" }};
+{{ if (and (eq $listen_port "80") ($.SSL_INUSE)) }}
+  return 301 https://$host:{{ $.PROXY_SSL_PORT }}$request_uri;
+{{ else }}
+  location    / {
+
+    gzip on;
+    gzip_min_length  1100;
+    gzip_buffers  4 32k;
+    gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+    gzip_vary on;
+    gzip_comp_level  6;
+
+    proxy_pass  http://{{ $.APP }}-{{ $upstream_port }};
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $http_connection;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Request-Start $msec;
+  }
+  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
+
+  error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+  location /400-error.html {
+    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
+    internal;
+  }
+
+  error_page 404 /404-error.html;
+  location /404-error.html {
+    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
+    internal;
+  }
+
+  error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+  location /500-error.html {
+    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
+    internal;
+  }
+{{ end }}
+}
+{{ else if eq $scheme "https"}}
+server {
+  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ else if eq $.SPDY_SUPPORTED "true" }}spdy{{ end }};
+  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ else if eq $.SPDY_SUPPORTED "true" }}spdy{{ end }};
+  {{ if $.SSL_SERVER_NAME }}server_name {{ $.SSL_SERVER_NAME }}; {{ end }}
+  {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
+  access_log  {{ $.NGINX_ACCESS_LOG_PATH }};
+  error_log   {{ $.NGINX_ERROR_LOG_PATH }};
+  client_max_body_size {{ var "NGINX_MAX_REQUEST_BODY" }};
+
+  ssl_certificate           {{ $.APP_SSL_PATH }}/server.crt;
+  ssl_certificate_key       {{ $.APP_SSL_PATH }}/server.key;
+  ssl_protocols             TLSv1.2 {{ if eq $.TLS13_SUPPORTED "true" }}TLSv1.3{{ end }};
+  ssl_prefer_server_ciphers off;
+
+  keepalive_timeout   70;
+  {{ if and (eq $.SPDY_SUPPORTED "true") (ne $.HTTP2_SUPPORTED "true") }}add_header          Alternate-Protocol  {{ $.PROXY_SSL_PORT }}:npn-spdy/2;{{ end }}
+
+  location    / {
+
+    gzip on;
+    gzip_min_length  1100;
+    gzip_buffers  4 32k;
+    gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+    gzip_vary on;
+    gzip_comp_level  6;
+
+    proxy_pass  http://{{ $.APP }}-{{ $upstream_port }};
+    {{ if eq $.HTTP2_PUSH_SUPPORTED "true" }}http2_push_preload on; {{ end }}
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $http_connection;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Request-Start $msec;
+  }
+  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
+
+  error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+  location /400-error.html {
+    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
+    internal;
+  }
+
+  error_page 404 /404-error.html;
+  location /404-error.html {
+    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
+    internal;
+  }
+
+  error_page 500 501 503 504 505 506 507 508 509 510 511 /500-error.html;
+  location /500-error.html {
+    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
+    internal;
+  }
+
+  error_page 502 /502-error.html;
+  location /502-error.html {
+    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
+    internal;
+  }
+}
+{{ else if eq $scheme "grpc"}}
+{{ if eq $.GRPC_SUPPORTED "true"}}{{ if eq $.HTTP2_SUPPORTED "true"}}
+server {
+  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} http2;
+  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} http2;
+  {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
+  access_log  {{ $.NGINX_ACCESS_LOG_PATH }};
+  error_log   {{ $.NGINX_ERROR_LOG_PATH }};
+  client_max_body_size {{ var "NGINX_MAX_REQUEST_BODY" }};
+  location    / {
+    grpc_pass  grpc://{{ $.APP }}-{{ $upstream_port }};
+  }
+  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
+}
+{{ end }}{{ end }}
+{{ else if eq $scheme "grpcs"}}
+{{ if eq $.GRPC_SUPPORTED "true"}}{{ if eq $.HTTP2_SUPPORTED "true"}}
+server {
+  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} ssl http2;
+  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} ssl http2;
+  {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
+  access_log  {{ $.NGINX_ACCESS_LOG_PATH }};
+  error_log   {{ $.NGINX_ERROR_LOG_PATH }};
+  client_max_body_size {{ var "NGINX_MAX_REQUEST_BODY" }};
+
+  ssl_certificate           {{ $.APP_SSL_PATH }}/server.crt;
+  ssl_certificate_key       {{ $.APP_SSL_PATH }}/server.key;
+  ssl_protocols             TLSv1.2 {{ if eq $.TLS13_SUPPORTED "true" }}TLSv1.3{{ end }};
+  ssl_prefer_server_ciphers off;
+
+  location    / {
+    grpc_pass  grpc://{{ $.APP }}-{{ $upstream_port }};
+  }
+  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
+}
+{{ end }}{{ end }}
+{{ end }}
+{{ end }}
+
+{{ if $.DOKKU_APP_WEB_LISTENERS }}
+{{ range $upstream_port := $.PROXY_UPSTREAM_PORTS | split " " }}
+upstream {{ $.APP }}-{{ $upstream_port }} {
+{{ range $listeners := $.DOKKU_APP_WEB_LISTENERS | split " " }}
+{{ $listener_list := $listeners | split ":" }}
+{{ $listener_ip := index $listener_list 0 }}
+  server {{ $listener_ip }}:{{ $upstream_port }};{{ end }}
+}
+{{ end }}{{ end }}


### PR DESCRIPTION
nginx has the default `client_max_body_size` to `1MB`, but clients like `s3cmd` and `s4cmd` use a greater multipart size when uploading files to S3. This pull request uses Dokku's custom nginx config to set `client_max_body_size` according to the app environment variable `NGINX_MAX_REQUEST_BODY`.
This pull request fixes issue #7.