### PR TITLE
Resolve "Docker build step fails creating dokku user" #14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM minio/minio:latest
 
 # Add user dokku with an individual UID
-RUN adduser -D -u 32769 -g dokku dokku
+RUN adduser -D -u 32769 dokku
 USER dokku
 
 # Create data directory for the user, where we will keep the data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM minio/minio:latest
 
 # Add user dokku with an individual UID
-RUN adduser -D -u 32769 dokku
+RUN adduser -u 32769 -m -U dokku
 USER dokku
 
 # Create data directory for the user, where we will keep the data


### PR DESCRIPTION
When I was deploying this repo to my dokku instance, it was failing the build step because of a problem with the line that creates the user. The adduser command failed because the dokku group didn't exist.

This PR fixes the issue and allows the image to be built when deploying the app to dokku. I don't think that this has any adverse effects on the app running in production, but I haven't tested it extensively because I'm not using Minio in my apps yet. I would appreciate a review to confirm that things work as expected before accepting and merging the PR.

Closes #14 