### PR TITLE
Change minio user/password environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ and object management. The following commands sets a random strings for each
 access key.
 
 ```bash
-dokku config:set --no-restart minio MINIO_ACCESS_KEY=$(echo `openssl rand -base64 45` | tr -d \=+ | cut -c 1-20)
-dokku config:set --no-restart minio MINIO_SECRET_KEY=$(echo `openssl rand -base64 45` | tr -d \=+ | cut -c 1-32)
+dokku config:set --no-restart minio MINIO_ROOT_USER=$(echo `openssl rand -base64 45` | tr -d \=+ | cut -c 1-20)
+dokku config:set --no-restart minio MINIO_ROOT_PASSWORD=$(echo `openssl rand -base64 45` | tr -d \=+ | cut -c 1-32)
 ```
 
 To login in the browser or via API, you will need to supply both the


### PR DESCRIPTION
The current minio/minio:latest says:
```
       WARNING: MINIO_ACCESS_KEY and MINIO_SECRET_KEY are deprecated.
                Please use MINIO_ROOT_USER and MINIO_ROOT_PASSWORD
```