### PR TITLE
Change console port and CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,4 @@ RUN mkdir -p /home/dokku/data
 WORKDIR /app
 ADD nginx.conf.sigil .
 
-# Run the server and point to the created directory
-CMD ["server", "/home/dokku/data"]
+CMD ["minio", "server", "/home/dokku/data", "--console-address", ":9001"]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ First add the correct port mapping for this project as defined in the parent
 
 ```bash
 dokku proxy:ports-add minio http:80:9000
+dokku proxy:ports-add minio https:443:9000
+dokku proxy:ports-add minio https:9001:9001
 ```
 
 Next remove the proxy mapping added by Dokku.


### PR DESCRIPTION
This change will force MinIO to run console on port 9001 and also will configure dokku proxy to route this port, so the user can access MinIO API (80/443) and console (9001).